### PR TITLE
Refactors default config generation

### DIFF
--- a/default_conf.go
+++ b/default_conf.go
@@ -1,0 +1,86 @@
+package httpd
+
+const (
+	httpdConf = `ServerRoot "${SERVER_ROOT}"
+
+ServerName "0.0.0.0"
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule unixd_module modules/mod_unixd.so
+{{if or .WebServerPushStateEnabled .WebServerForceHTTPS -}}
+LoadModule rewrite_module modules/mod_rewrite.so
+{{end}}
+{{- if .WebServerPushStateEnabled -}}
+LoadModule autoindex_module modules/mod_autoindex.so
+{{end}}
+{{- if .BasicAuthFile -}}
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+{{end}}
+TypesConfig conf/mime.types
+
+PidFile logs/httpd.pid
+
+User nobody
+
+Listen "${PORT}"
+
+DocumentRoot "{{.WebServerRoot}}"
+
+DirectoryIndex index.html
+
+ErrorLog logs/error_log
+
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog logs/access_log common
+
+<Directory />
+  AllowOverride None
+  Require all denied
+</Directory>
+
+<Directory "{{.WebServerRoot}}">
+{{- if .BasicAuthFile}}
+  Require valid-user
+{{- else}}
+  Require all granted
+{{- end}}
+{{- if .WebServerPushStateEnabled}}
+
+  Options +FollowSymLinks
+  IndexIgnore */*
+  RewriteEngine On
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule (.*) index.html
+{{- end}}
+{{- if .WebServerForceHTTPS}}
+
+  RewriteEngine On
+  RewriteCond %{HTTPS} !=on
+  RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
+  RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+{{- end}}
+{{- if .BasicAuthFile}}
+
+  AuthType Basic
+  AuthName "Authentication Required"
+  AuthUserFile "{{.BasicAuthFile}}"
+
+  Order allow,deny
+  Allow from all
+{{- end}}
+</Directory>
+
+<Files ".ht*">
+  Require all denied
+</Files>`
+)

--- a/fakes/generate_config.go
+++ b/fakes/generate_config.go
@@ -1,30 +1,36 @@
 package fakes
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/paketo-buildpacks/httpd"
+)
 
 type GenerateConfig struct {
 	GenerateCall struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			WorkingDir   string
-			PlatformPath string
+			WorkingDir       string
+			PlatformPath     string
+			BuildEnvironment httpd.BuildEnvironment
 		}
 		Returns struct {
 			Error error
 		}
-		Stub func(string, string) error
+		Stub func(string, string, httpd.BuildEnvironment) error
 	}
 }
 
-func (f *GenerateConfig) Generate(param1 string, param2 string) error {
+func (f *GenerateConfig) Generate(param1 string, param2 string, param3 httpd.BuildEnvironment) error {
 	f.GenerateCall.mutex.Lock()
 	defer f.GenerateCall.mutex.Unlock()
 	f.GenerateCall.CallCount++
 	f.GenerateCall.Receives.WorkingDir = param1
 	f.GenerateCall.Receives.PlatformPath = param2
+	f.GenerateCall.Receives.BuildEnvironment = param3
 	if f.GenerateCall.Stub != nil {
-		return f.GenerateCall.Stub(param1, param2)
+		return f.GenerateCall.Stub(param1, param2, param3)
 	}
 	return f.GenerateCall.Returns.Error
 }

--- a/generate_httpd_config_test.go
+++ b/generate_httpd_config_test.go
@@ -50,7 +50,7 @@ func testGenerateHTTPDConfig(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("create a default httpd config", func() {
-			err := generateHTTPDConfig.Generate(workingDir, "platform")
+			err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("htpasswd"))
@@ -106,16 +106,8 @@ CustomLog logs/access_log common
 
 		context("when BP_WEB_SERVER_ROOT is set", func() {
 			context("when the path given is no absolute", func() {
-				it.Before(func() {
-					os.Setenv("BP_WEB_SERVER_ROOT", "htdocs")
-				})
-
-				it.After(func() {
-					os.Unsetenv("BP_WEB_SERVER_ROOT")
-				})
-
 				it("creates a config with the adjusted DocumentRoot and Directory path", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
+					err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{WebServerRoot: "htdocs"})
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("htpasswd"))
@@ -171,16 +163,8 @@ CustomLog logs/access_log common
 			})
 
 			context("when the path given is absolute", func() {
-				it.Before(func() {
-					os.Setenv("BP_WEB_SERVER_ROOT", "/absolute/path")
-				})
-
-				it.After(func() {
-					os.Unsetenv("BP_WEB_SERVER_ROOT")
-				})
-
 				it("creates a config with the adjusted DocumentRoot and Directory path", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
+					err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{WebServerRoot: "/absolute/path"})
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("htpasswd"))
@@ -237,16 +221,8 @@ CustomLog logs/access_log common
 		})
 
 		context("when BP_WEB_SERVER_ENABLE_PUSH_STATE is set", func() {
-			it.Before(func() {
-				os.Setenv("BP_WEB_SERVER_ENABLE_PUSH_STATE", "true")
-			})
-
-			it.After(func() {
-				os.Unsetenv("BP_WEB_SERVER_ENABLE_PUSH_STATE")
-			})
-
 			it("creates a config with directices that force all routes to index.html", func() {
-				err := generateHTTPDConfig.Generate(workingDir, "platform")
+				err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{WebServerPushStateEnabled: true})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("htpasswd"))
@@ -311,16 +287,8 @@ CustomLog logs/access_log common
 		})
 
 		context("when BP_WEB_SERVER_FORCE_HTTPS is set", func() {
-			it.Before(func() {
-				os.Setenv("BP_WEB_SERVER_FORCE_HTTPS", "true")
-			})
-
-			it.After(func() {
-				os.Unsetenv("BP_WEB_SERVER_FORCE_HTTPS")
-			})
-
 			it("creates a config with directives that force redirect to https", func() {
-				err := generateHTTPDConfig.Generate(workingDir, "platform")
+				err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{WebServerForceHTTPS: true})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("htpasswd"))
@@ -396,7 +364,7 @@ CustomLog logs/access_log common
 			})
 
 			it("creates a config with that requires basic auth", func() {
-				err := generateHTTPDConfig.Generate(workingDir, "platform")
+				err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("htpasswd"))
@@ -475,38 +443,8 @@ CustomLog logs/access_log common
 				})
 
 				it("returns an error", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
+					err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{})
 					Expect(err).To(MatchError(ContainSubstring("permission denied")))
-				})
-			})
-
-			context("when BP_WEB_SERVER_ENABLE_PUSH_STATE is an invalid value", func() {
-				it.Before(func() {
-					os.Setenv("BP_WEB_SERVER_ENABLE_PUSH_STATE", "banana")
-				})
-
-				it.After(func() {
-					os.Unsetenv("BP_WEB_SERVER_ENABLE_PUSH_STATE")
-				})
-
-				it("returns an error", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
-					Expect(err).To(MatchError(ContainSubstring(`failed to parse BP_WEB_SERVER_ENABLE_PUSH_STATE value banana: strconv.ParseBool: parsing "banana": invalid syntax`)))
-				})
-			})
-
-			context("when BP_WEB_SERVER_FORCE_HTTPS is an invalid value", func() {
-				it.Before(func() {
-					os.Setenv("BP_WEB_SERVER_FORCE_HTTPS", "banana")
-				})
-
-				it.After(func() {
-					os.Unsetenv("BP_WEB_SERVER_FORCE_HTTPS")
-				})
-
-				it("returns an error", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
-					Expect(err).To(MatchError(ContainSubstring(`failed to parse BP_WEB_SERVER_FORCE_HTTPS value banana: strconv.ParseBool: parsing "banana": invalid syntax`)))
 				})
 			})
 
@@ -515,7 +453,7 @@ CustomLog logs/access_log common
 					bindingResolver.ResolveCall.Returns.Error = errors.New("failed to resolve binding")
 				})
 				it("returns an error", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
+					err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{})
 					Expect(err).To(MatchError("failed to resolve binding"))
 				})
 			})
@@ -542,7 +480,7 @@ CustomLog logs/access_log common
 					}
 				})
 				it("returns an error", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
+					err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{})
 					Expect(err).To(MatchError("failed: binding resolver found more than one binding of type 'htpasswd'"))
 				})
 			})
@@ -561,7 +499,7 @@ CustomLog logs/access_log common
 					}
 				})
 				it("returns an error", func() {
-					err := generateHTTPDConfig.Generate(workingDir, "platform")
+					err := generateHTTPDConfig.Generate(workingDir, "platform", httpd.BuildEnvironment{})
 					Expect(err).To(MatchError("failed: binding of type 'htpasswd' does not contain required entry '.htpasswd'"))
 				})
 			})

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v1.1.0
 	github.com/Masterminds/semver v1.5.0
+	github.com/caarlos0/env/v6 v6.9.1
 	github.com/onsi/gomega v1.19.0
 	github.com/paketo-buildpacks/occam v0.7.0
 	github.com/paketo-buildpacks/packit/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/caarlos0/env/v6 v6.9.1 h1:zOkkjM0F6ltnQ5eBX6IPI41UP/KDGEK7rRPwGCNos8k=
+github.com/caarlos0/env/v6 v6.9.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/run/main.go
+++ b/run/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/paketo-buildpacks/httpd"
+
+	"github.com/caarlos0/env/v6"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
@@ -21,9 +24,20 @@ func main() {
 	entryResolver := draft.NewPlanner()
 	generateHTTPDConfig := httpd.NewGenerateHTTPDConfig(servicebindings.NewResolver(), logEmitter)
 
+	var buildEnvironment httpd.BuildEnvironment
+	err := env.Parse(&buildEnvironment)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Errorf("failed to parse build configuration: %w", err))
+		os.Exit(1)
+	}
+
 	packit.Run(
-		httpd.Detect(versionParser),
+		httpd.Detect(
+			buildEnvironment,
+			versionParser,
+		),
 		httpd.Build(
+			buildEnvironment,
 			entryResolver,
 			dependencyService,
 			generateHTTPDConfig,


### PR DESCRIPTION
- Moves default template into a separate file but keeps it as const for
testing purposes
- Start using an env parser to configure build environment

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
