### PR TITLE
Update the layer name to a generic one that takes the buildpack ID

### DIFF
--- a/integration/caching_test.go
+++ b/integration/caching_test.go
@@ -110,7 +110,7 @@ func testCaching(t *testing.T, when spec.G, it spec.S) {
 			"",
 			MatchRegexp(`    Selected Apache HTTP Server version \(using \<unknown\>\): 2\.4\.\d+`),
 			"",
-			"  Reusing cached layer /layers/paketo-buildpacks_httpd/httpd",
+			fmt.Sprintf("  Reusing cached layer /layers/%s/httpd", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			"",
 			"  Assigning launch processes:",
 			"    web (default): httpd -f /workspace/httpd.conf -k start -DFOREGROUND",


### PR DESCRIPTION
## Summary
Currently, the tests are validating that the layer name contains the name "paketo_buildpacks" which makes these tests very specific to this organization.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
