### PR TITLE
Allow build/run image UIDs to differ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin
 *.tgz
 httpd_*
+/build/

--- a/default_conf.go
+++ b/default_conf.go
@@ -27,7 +27,7 @@ LoadModule auth_basic_module modules/mod_auth_basic.so
 {{end}}
 TypesConfig conf/mime.types
 
-PidFile logs/httpd.pid
+PidFile /tmp/httpd.pid
 
 User nobody
 
@@ -37,10 +37,10 @@ DocumentRoot "{{.WebServerRoot}}"
 
 DirectoryIndex index.html
 
-ErrorLog logs/error_log
+ErrorLog /proc/self/fd/2
 
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
-CustomLog logs/access_log common
+CustomLog /proc/self/fd/1 common
 
 <Directory />
   AllowOverride None

--- a/generate_httpd_config_test.go
+++ b/generate_httpd_config_test.go
@@ -75,7 +75,7 @@ LoadModule unixd_module modules/mod_unixd.so
 
 TypesConfig conf/mime.types
 
-PidFile logs/httpd.pid
+PidFile /tmp/httpd.pid
 
 User nobody
 
@@ -85,10 +85,10 @@ DocumentRoot "${APP_ROOT}/public"
 
 DirectoryIndex index.html
 
-ErrorLog logs/error_log
+ErrorLog /proc/self/fd/2
 
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
-CustomLog logs/access_log common
+CustomLog /proc/self/fd/1 common
 
 <Directory />
   AllowOverride None
@@ -132,7 +132,7 @@ LoadModule unixd_module modules/mod_unixd.so
 
 TypesConfig conf/mime.types
 
-PidFile logs/httpd.pid
+PidFile /tmp/httpd.pid
 
 User nobody
 
@@ -142,10 +142,10 @@ DocumentRoot "${APP_ROOT}/htdocs"
 
 DirectoryIndex index.html
 
-ErrorLog logs/error_log
+ErrorLog /proc/self/fd/2
 
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
-CustomLog logs/access_log common
+CustomLog /proc/self/fd/1 common
 
 <Directory />
   AllowOverride None
@@ -189,7 +189,7 @@ LoadModule unixd_module modules/mod_unixd.so
 
 TypesConfig conf/mime.types
 
-PidFile logs/httpd.pid
+PidFile /tmp/httpd.pid
 
 User nobody
 
@@ -199,10 +199,10 @@ DocumentRoot "/absolute/path"
 
 DirectoryIndex index.html
 
-ErrorLog logs/error_log
+ErrorLog /proc/self/fd/2
 
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
-CustomLog logs/access_log common
+CustomLog /proc/self/fd/1 common
 
 <Directory />
   AllowOverride None
@@ -249,7 +249,7 @@ LoadModule autoindex_module modules/mod_autoindex.so
 
 TypesConfig conf/mime.types
 
-PidFile logs/httpd.pid
+PidFile /tmp/httpd.pid
 
 User nobody
 
@@ -259,10 +259,10 @@ DocumentRoot "${APP_ROOT}/public"
 
 DirectoryIndex index.html
 
-ErrorLog logs/error_log
+ErrorLog /proc/self/fd/2
 
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
-CustomLog logs/access_log common
+CustomLog /proc/self/fd/1 common
 
 <Directory />
   AllowOverride None
@@ -314,7 +314,7 @@ LoadModule rewrite_module modules/mod_rewrite.so
 
 TypesConfig conf/mime.types
 
-PidFile logs/httpd.pid
+PidFile /tmp/httpd.pid
 
 User nobody
 
@@ -324,10 +324,10 @@ DocumentRoot "${APP_ROOT}/public"
 
 DirectoryIndex index.html
 
-ErrorLog logs/error_log
+ErrorLog /proc/self/fd/2
 
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
-CustomLog logs/access_log common
+CustomLog /proc/self/fd/1 common
 
 <Directory />
   AllowOverride None
@@ -395,7 +395,7 @@ LoadModule auth_basic_module modules/mod_auth_basic.so
 
 TypesConfig conf/mime.types
 
-PidFile logs/httpd.pid
+PidFile /tmp/httpd.pid
 
 User nobody
 
@@ -405,10 +405,10 @@ DocumentRoot "${APP_ROOT}/public"
 
 DirectoryIndex index.html
 
-ErrorLog logs/error_log
+ErrorLog /proc/self/fd/2
 
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
-CustomLog logs/access_log common
+CustomLog /proc/self/fd/1 common
 
 <Directory />
   AllowOverride None

--- a/integration/testdata/simple_app/httpd.conf
+++ b/integration/testdata/simple_app/httpd.conf
@@ -63,7 +63,7 @@ LogLevel info
 </IfModule>
 
 <IfModule !mpm_netware_module>
-    PidFile "logs/httpd.pid"
+    PidFile "/tmp/httpd.pid"
 </IfModule>
 <IfModule mpm_worker_module>
     StartServers             3


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In order to support Jammy and other stacks where the UIDs differ between the build and run  images, we will need to make some changes to the default configuration we apply in the "zero-config" feature.

Specifically, we need to write the access and error logs to stdout and stderr, respectively. Additionally, the PID file should be written to a location that is commonly shared like `/tmp`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Making these changes will enable this buildpack to run on a stack where the UIDs of the `cnb` user differ.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
