### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.8"
   homepage = "https://github.com/paketo-buildpacks/httpd"
   id = "paketo-buildpacks/httpd"
   keywords = ["apache", "httpd", "server", "distribution"]
-  name = "Paketo Apache HTTP Server Buildpack"
+  name = "Paketo Buildpack for Apache HTTP Server"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
 [metadata]


### PR DESCRIPTION
Renames 'Paketo Apache HTTP Server Buildpack' to 'Paketo Buildpack for Apache HTTP Server'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
