### PR TITLE
Fix malformed checksum for retrieval and compile

### DIFF
--- a/dependency/actions/compile/entrypoint
+++ b/dependency/actions/compile/entrypoint
@@ -186,7 +186,7 @@ function main() {
     mv temp.tgz "${OUTPUT_TARBALL_NAME}"
 
     echo "Creating checksum file for ${OUTPUT_TARBALL_NAME}"
-    echo "${SHA256}" > "${OUTPUT_SHAFILE_NAME}"
+    echo "sha256:${SHA256}" > "${OUTPUT_SHAFILE_NAME}"
   popd
 }
 

--- a/dependency/retrieval/retrieve.go
+++ b/dependency/retrieval/retrieve.go
@@ -155,9 +155,9 @@ func generateMetadata(hasVersion versionology.VersionFetcher) ([]versionology.De
 	dep := cargo.ConfigMetadataDependency{
 		Version:         httpdVersion,
 		ID:              "httpd",
-		Name:            "HTTPD",
+		Name:            "Apache HTTP Server",
 		Source:          release.dependencyURL,
-		SourceChecksum:  sourceSHA,
+		SourceChecksum:  fmt.Sprintf("sha256:%s", sourceSHA),
 		DeprecationDate: nil,
 		Licenses:        retrieve.LookupLicenses(release.dependencyURL, decompress),
 		PURL:            retrieve.GeneratePURL("httpd", httpdVersion, sourceSHA, release.dependencyURL),


### PR DESCRIPTION
Prepends `sha256:` to checksum hash