### PR TITLE
dependency: older git version on bionic has no sorting

### DIFF
--- a/dependency/actions/compile/bionic.Dockerfile
+++ b/dependency/actions/compile/bionic.Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:18.04
 
 RUN apt-get -y update
-RUN apt-get -y install build-essential curl git zlib1g zlib1g-dev libldap2-dev libjansson-dev libcjose-dev libhiredis-dev libssl-dev libpcre3 libpcre3-dev libexpat1 libexpat1-dev
+RUN apt-get -y install build-essential curl software-properties-common zlib1g zlib1g-dev libldap2-dev libjansson-dev libcjose-dev libhiredis-dev libssl-dev libpcre3 libpcre3-dev libexpat1 libexpat1-dev
+
+# Because bionic comes with older git version 2.17.1
+# that does not support --sort for ls-remote
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get -y update && apt-get -y install git
 
 ARG cnb_uid=0
 ARG cnb_gid=0


### PR DESCRIPTION
This is a follow-up to #470 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
